### PR TITLE
Add delimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   live in their own module.
 * Add a lot more functions and attempt to make naming somewhat
   consistent.
+* Add `delimit`.
+* Add `annotate` and its infix synonym `<?>`.
 
 ## 0.1.0.0 -- 2019-08-22
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -32,6 +32,19 @@ tests :: TestTree
 tests = testGroup "Parser"
   [ testProperty "decStandardInt" $ \i ->
       P.parseBytes (Latin.decStandardInt ()) (bytes (show i)) === P.Success i 0
+  , testCase "delimit" $
+      P.Success (167,14625) 0
+      @=?
+      P.parseBytes
+        (do len <- Latin.decUnsignedInt ()
+            Latin.char () ','
+            r <- P.delimit () () len $ (,)
+              <$> Latin.decUnsignedInt ()
+              <*  Latin.char () '*'
+              <*> Latin.decUnsignedInt ()
+            Latin.char () '0'
+            pure r
+        ) (bytes "9,167*146250")
   , testGroup "decUnsignedInt"
     [ testCase "A" $
         P.Failure ()


### PR DESCRIPTION
This is a response (in a different library albeit) to and old [attoparsec issue](https://github.com/bos/attoparsec/issues/129): can we have a combinator that delimits a subparser? Yes, we can. The pattern of prefixing a portion of a document with its length shows up all over the place in the world of encoding schemes. To name a few: kafka, postgresql, ASN.1. This PR adds `delimit`, which makes getting this right easy for the users.